### PR TITLE
use https for pip install ha@dev

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN python -m pip install --upgrade colorlog black pylint
-RUN python -m pip install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+RUN python -m pip install --upgrade git+https://github.com/home-assistant/home-assistant@dev
 RUN cd && mkdir -p /config/custom_components
 
 

--- a/.devcontainer/custom_component_helper
+++ b/.devcontainer/custom_component_helper
@@ -13,7 +13,7 @@ function StartHomeAssistant {
 }
 
 function UpdgradeHomeAssistantDev {
-  python -m pip install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev
+  python -m pip install --upgrade git+https://github.com/home-assistant/home-assistant@dev
 }
 
 function SetHomeAssistantVersion {


### PR DESCRIPTION
I could not open the remote container because the step `RUN python -m pip install --upgrade git+git://github.com/home-assistant/home-assistant.git@dev` failed with an error code 128.

Using https and removing the *.git* worked for me